### PR TITLE
Bumping susy version to current

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source :rubygems
 gem "middleman", "~>3.0.5"
 gem "middleman-favicon-maker"
 gem "middleman-livereload"
-gem "susy", "1.0"
+gem "susy", "~>1.0.5"
 gem "redcarpet"
 
 gem 'coffee-filter' # Coffeescript filter for HAML

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,10 @@ GEM
       i18n (~> 0.6)
       multi_json (~> 1.0)
     addressable (2.3.2)
-    chunky_png (1.2.6)
+    chunky_png (1.2.7)
+    coffee-filter (0.1.1)
+      coffee-script (>= 2.2.0)
+      haml (>= 3.0.18)
     coffee-script (2.2.0)
       coffee-script-source
       execjs
@@ -94,7 +97,7 @@ GEM
     rb-inotify (0.8.8)
       ffi (>= 0.5.0)
     redcarpet (2.1.1)
-    sass (3.2.1)
+    sass (3.2.5)
     sinatra (1.3.3)
       rack (~> 1.3, >= 1.3.6)
       rack-protection (~> 1.2)
@@ -108,7 +111,7 @@ GEM
       sprockets (~> 2.0)
       tilt (~> 1.1)
     subexec (0.2.2)
-    susy (1.0)
+    susy (1.0.5)
       compass (>= 0.12.2)
       sass (>= 3.2.0)
     syntax (1.0.0)
@@ -124,8 +127,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  coffee-filter
   middleman (~> 3.0.5)
   middleman-favicon-maker
   middleman-livereload
   redcarpet
-  susy (= 1.0)
+  susy (~> 1.0.5)


### PR DESCRIPTION
Using the "twiddle-waka" syntax in the Gemfile allows the susy gem to be
updated with patch releases with `bundle update susy`.
