### PR TITLE
Add missing IE conditional comment.

### DIFF
--- a/helpers/site_helpers.rb
+++ b/helpers/site_helpers.rb
@@ -1,5 +1,16 @@
 module SiteHelpers
 
+  def ie_html_tag attributes = {}, &block
+    haml_concat "<!--[if lt IE 7]> #{tag :html, with_classes(attributes, %w{lt-ie9 lt-ie8 lt-ie7})} <![endif]-->"
+    haml_concat "<!--[if IE 7]>    #{tag :html, with_classes(attributes, %w{lt-ie9 lt-ie8})}        <![endif]-->"
+    haml_concat "<!--[if IE 8]>    #{tag :html, with_classes(attributes, %w{lt-ie9})}               <![endif]-->"
+    haml_concat '<!--[if gt IE 8]><!-->'
+    haml_tag :html, attributes do
+      haml_concat '<!--<![endif]-->'
+      block.call
+    end
+  end
+
   def page_title
     title = "Set your site title in /helpers/site_helpers.rb"
     if data.page.title
@@ -15,6 +26,14 @@ module SiteHelpers
       description = "Set your site description in /helpers/site_helpers.rb"
     end
     description
+  end
+
+  private
+
+  def with_classes attributes, classes
+    existing_classes = attributes[:class].to_s.split(' ')
+    class_attribute = existing_classes.concat(classes).uniq.join(' ')
+    attributes.merge :class => class_attribute
   end
 
 end

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -1,8 +1,4 @@
-!!!5
-/[if lt IE 7] <html class="no-js lt-ie9 lt-ie8 lt-ie7">
-/[if IE 7] <html class="no-js lt-ie9 lt-ie8">
-/[if IE 8] <html class="no-js lt-ie9">
-%html.no-js
+- ie_html_tag :class => 'no-js' do
   %head
     %meta{:charset => "utf-8"}
     %meta{:content => "IE=edge,chrome=1", "http-equiv" => "X-UA-Compatible"}

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -1,3 +1,4 @@
+!!!5
 - ie_html_tag :class => 'no-js' do
   %head
     %meta{:charset => "utf-8"}


### PR DESCRIPTION
It looks like the template is currently missing [one of the IE conditional comments](https://github.com/h5bp/html5-boilerplate/blob/6be0119cd2560e31a95383e5ba89963ca576dfea/index.html#L5), which I imagine results in multiple opening `html` tags in IE versions 8 and below.

This patch adds a helper in the style of [sporkd/compass-html5-boilerplate](https://github.com/sporkd/compass-html5-boilerplate/blob/d34fd479/lib/app/helpers/html5_boilerplate_helper.rb#L5).
