### PR TITLE
Gemfile update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "middleman", "~>3.0.5"
 gem "middleman-favicon-maker"


### PR DESCRIPTION
Hello,

`source :rubygems` is deprecated in `Gemfile` since recent security issues with rubygems.
This cause a warning when you run `bundle install`.

This commit replace this line with the `https` address and suppress the warning.
