### PR TITLE
Changes source to https://rubygems.org.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "middleman", "~>3.0.5"
 gem "middleman-favicon-maker"


### PR DESCRIPTION
Using `source :rubygems` will nowadays throw a warning:

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or
'http://rubygems.org' if not.
```

This should get rid of it.
