### PR TITLE
Simple fixes to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,7 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "middleman", "~>3.0.5"
 gem "middleman-favicon-maker"
 gem "middleman-livereload"
 gem "susy", "~>1.0.5"
 gem "redcarpet"
-
-gem 'coffee-filter' # Coffeescript filter for HAML


### PR DESCRIPTION
Bundler requested that source be changed to 'https://rubygems.org'.
Removed the requirement for coffee-filter. According to:

https://github.com/middleman/middleman/issues/813

Coffee-filter is no longer necessary because it's built into HAML 4.
This solved Middleman runtime errors for me.
